### PR TITLE
[Fixed conflicts] Fixed misspellings and fuzzy translations in Dutch, French, Italian, Portuguese and Spanish

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: oomox\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-22 07:27+0100\n"
-"PO-Revision-Date: 2019-02-21 20:24-0300\n"
+"PO-Revision-Date: 2019-02-21 11:50-0300\n"
 "Last-Translator: Gustavo Costa <gusbemacbe@gmail.com>\n"
 "Language-Team: Spanish <gusbemacbe@gmail.com>\n"
 "Language: es \n"
@@ -319,12 +319,10 @@ msgid "Header Text"
 msgstr "Texto de encabezado"
 
 #: oomox_gui/theme_model.py:154
-#, fuzzy
 msgid "Selected Background"
 msgstr "Fondo de la barra de encabezado"
 
 #: oomox_gui/theme_model.py:160
-#, fuzzy
 msgid "Selected Text"
 msgstr "Texto de la selección"
 
@@ -596,9 +594,8 @@ msgid "Border"
 msgstr "Borde"
 
 #: plugins/theme_arc/oomox_plugin.py:174
-#, fuzzy
 msgid "Enable Theme Transparency"
-msgstr "Habilitar la transparencia del tema del GTK3"
+msgstr "Habilitar la transparencia del tema"
 
 #: plugins/theme_materia/oomox_plugin.py:96
 msgid "View"
@@ -657,22 +654,18 @@ msgid "Spotify"
 msgstr "Spotify"
 
 #: plugins/icons_suruplus/oomox_plugin.py:58
-#, fuzzy
 msgid "Export _path: "
-msgstr "_Camino del Spotify:"
+msgstr "Exportar el _camino: "
 
 #: plugins/icons_suruplus/oomox_plugin.py:116
-#, fuzzy
 msgid "Enable Gradients"
 msgstr "Habilitar los gradientes"
 
 #: plugins/icons_suruplus/oomox_plugin.py:122
-#, fuzzy
 msgid "Gradient Start Color"
 msgstr "Color del gradiente primario"
 
 #: plugins/icons_suruplus/oomox_plugin.py:131
-#, fuzzy
 msgid "Gradient End Color"
 msgstr "Color del gradiente secundario"
 
@@ -685,19 +678,16 @@ msgstr ""
 "en lugar de ambas 3.18 y 3.20+"
 
 #: plugins/theme_oomox/oomox_plugin.py:107
-#, fuzzy
 msgid "Textbox Caret"
-msgstr "Texto del cuadro del texto"
+msgstr "Cursor del cuadro del texto"
 
 #: plugins/theme_oomox/oomox_plugin.py:113
-#, fuzzy
 msgid "BiDi Textbox Caret"
-msgstr "Texto del cuadro del texto"
+msgstr "Cursor del cuadro del texto BiDi"
 
 #: plugins/theme_oomox/oomox_plugin.py:122
-#, fuzzy
 msgid "Textbox Caret Aspect Ratio"
-msgstr "Botón de radio del cursor"
+msgstr "Botón de radio del cursor del cuardo del texto"
 
 #: plugins/theme_oomox/oomox_plugin.py:126
 msgid "GTK3 Theme Options"
@@ -736,14 +726,12 @@ msgid "Unity: Use Default Launcher Style"
 msgstr "Unity: Utilizar el estilo de lanzacohetes estándar"
 
 #: plugins/import_pil/oomox_plugin.py:56
-#, fuzzy
 msgid "Image colors"
-msgstr "colores del terminal:"
+msgstr "colores de la imagen"
 
 #: plugins/import_pil/oomox_plugin.py:57
-#, fuzzy
 msgid "Colors from Image"
-msgstr "Importar los colores de la imagem"
+msgstr "Colores a partir de la imagen"
 
 #: plugins/import_pil/oomox_plugin.py:189
 msgid "Import Colors from Image"
@@ -837,11 +825,9 @@ msgstr "Color de iconos"
 #~ msgid "Secondary Caret Color"
 #~ msgstr "Color del cursor secundario"
 
-#, fuzzy
 #~ msgid "_Export Theme…"
-#~ msgstr "_Exportar el tema"
+#~ msgstr "_Exportar el tema…"
 
-#, fuzzy
 #~ msgid "Selection Highlight"
 #~ msgstr "Realce de selección"
 
@@ -872,23 +858,18 @@ msgstr "Color de iconos"
 #~ msgid "Other options"
 #~ msgstr "Otros ajustes"
 
-#, fuzzy
 #~ msgid "Please choose the font options:"
 #~ msgstr "Por favor escoge los ajustes de la fuente:"
 
-#, fuzzy
 #~ msgid "Spotify background"
 #~ msgstr "Fondo del Spotify"
 
-#, fuzzy
 #~ msgid "Spotify foreground"
 #~ msgstr "Primer plano del Spotify"
 
-#, fuzzy
 #~ msgid "Theme options:"
 #~ msgstr "Ajustes del tena:"
 
-#, fuzzy
 #~ msgid "Theme options: "
 #~ msgstr "Ajustes del tena:"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: oomox\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-22 07:27+0100\n"
-"PO-Revision-Date: 2019-02-22 04:37-0300\n"
+"PO-Revision-Date: 2019-02-21 11:50-0300\n"
 "Last-Translator: Gustavo Costa <gusbemacbe@gmail.com>\n"
 "Language-Team: French <gusbemacbe@gmail.com>\n"
 "Language: fr\n"
@@ -60,7 +60,7 @@ msgstr ""
 
 #: oomox_gui/export_common.py:202
 msgid "Terminal Colorscheme"
-msgstr "Thème de couleurs do terminal"
+msgstr "Thème de couleurs du terminal"
 
 #: oomox_gui/export_common.py:207
 msgid "Paste this colorscheme to your ~/.Xresources:"
@@ -312,21 +312,19 @@ msgstr "Texte"
 
 #: oomox_gui/theme_model.py:142
 msgid "Header Background"
-msgstr "Arrière-plan bouton d'en-tête"
+msgstr "Arrière-plan du texte d'en-tête"
 
 #: oomox_gui/theme_model.py:148
 msgid "Header Text"
-msgstr "Texte des boutons d'en-tête"
+msgstr "Texte d'en-tête"
 
 #: oomox_gui/theme_model.py:154
-#, fuzzy
 msgid "Selected Background"
-msgstr "Arrière-plan bouton d'en-tête"
+msgstr "Arrière-plan sélectionné"
 
 #: oomox_gui/theme_model.py:160
-#, fuzzy
 msgid "Selected Text"
-msgstr "Texte de la sélection"
+msgstr "Texte sélectionné"
 
 #: oomox_gui/theme_model.py:166
 msgid "Accent Color (Checkboxes, Radios)"
@@ -334,15 +332,15 @@ msgstr "Couleur primaire (cases à cocher, cases d'option)"
 
 #: oomox_gui/theme_model.py:172
 msgid "Textbox Background"
-msgstr "Arrière-plan zone de texte"
+msgstr "Arrière-plan de la zone de texte"
 
 #: oomox_gui/theme_model.py:178
 msgid "Textbox Text"
-msgstr "Zone de texte"
+msgstr "Text de la zone de texte"
 
 #: oomox_gui/theme_model.py:184
 msgid "Button Background"
-msgstr "Arrière-plan bouton"
+msgstr "Arrière-plan des boutons"
 
 #: oomox_gui/theme_model.py:190
 msgid "Button Text"
@@ -350,7 +348,7 @@ msgstr "Texte des boutons"
 
 #: oomox_gui/theme_model.py:196
 msgid "Header Button Background"
-msgstr "Arrière-plan bouton d'en-tête"
+msgstr "Arrière-plan du text d'en-tête"
 
 #: oomox_gui/theme_model.py:202
 msgid "Header Button Text"
@@ -406,7 +404,7 @@ msgstr "Manuel"
 
 #: oomox_gui/theme_model.py:325 plugins/oomoxify/oomox_plugin.py:159
 msgid "Foreground"
-msgstr "Avant-plan/texte"
+msgstr "Avant-plan"
 
 #: oomox_gui/theme_model.py:334 plugins/oomoxify/oomox_plugin.py:165
 msgid "Accent Color"
@@ -418,7 +416,7 @@ msgstr "Échange automatique d'arrière-plan et avant-plan"
 
 #: oomox_gui/theme_model.py:353
 msgid "Extend Palette with More Lighter/Darker Colors"
-msgstr "Étendre la palette avec des couleurs plus claires/foncée"
+msgstr "Étendre la palette avec des couleurs plus claires/foncées"
 
 #: oomox_gui/theme_model.py:362
 msgid "Palette Generation Accuracy"
@@ -429,7 +427,6 @@ msgid "Black"
 msgstr "Noir"
 
 #: oomox_gui/theme_model.py:382
-#, fuzzy
 msgid "Black Highlight"
 msgstr "Surlignage noire"
 
@@ -438,7 +435,6 @@ msgid "Red"
 msgstr "Surlignage rouge"
 
 #: oomox_gui/theme_model.py:399
-#, fuzzy
 msgid "Red Highlight"
 msgstr "Surlignage rouge"
 
@@ -447,7 +443,6 @@ msgid "Green"
 msgstr "Vert"
 
 #: oomox_gui/theme_model.py:416
-#, fuzzy
 msgid "Green Highlight"
 msgstr "Surlignage verte"
 
@@ -456,7 +451,6 @@ msgid "Yellow"
 msgstr "Jaune"
 
 #: oomox_gui/theme_model.py:433
-#, fuzzy
 msgid "Yellow Highlight"
 msgstr "Surlignage jaune"
 
@@ -465,7 +459,6 @@ msgid "Blue"
 msgstr "Bleu"
 
 #: oomox_gui/theme_model.py:450
-#, fuzzy
 msgid "Blue Highlight"
 msgstr "Surlignage bleu"
 
@@ -474,7 +467,6 @@ msgid "Purple"
 msgstr "Pourpre"
 
 #: oomox_gui/theme_model.py:467
-#, fuzzy
 msgid "Purple Highlight"
 msgstr "Surlignage pourpre"
 
@@ -483,7 +475,6 @@ msgid "Cyan"
 msgstr "Cyan"
 
 #: oomox_gui/theme_model.py:484
-#, fuzzy
 msgid "Cyan Highlight"
 msgstr "Surlignage cyan"
 
@@ -492,7 +483,6 @@ msgid "White"
 msgstr "Blanc"
 
 #: oomox_gui/theme_model.py:501
-#, fuzzy
 msgid "White Highlight"
 msgstr "Surlignage blanche"
 
@@ -523,7 +513,7 @@ msgstr "Trait sombre"
 
 #: plugins/base16/oomox_plugin.py:255
 msgid "Base16 Export Options…"
-msgstr "Options du thème du Base16…"
+msgstr "Options du thème du Base16 …"
 
 #: plugins/base16/oomox_plugin.py:258
 msgid "Choose export options below and copy-paste the result."
@@ -551,7 +541,7 @@ msgstr "Base16 importé par l'utilisateur"
 
 #: plugins/base16/oomox_plugin.py:310
 msgid "Base16-Based Templates…"
-msgstr "Modèles basés sur Base16…"
+msgstr "Modèles basés sur Base16 …"
 
 #: plugins/base16/oomox_plugin.py:311
 msgid "From Base16 YML Format"
@@ -604,7 +594,6 @@ msgid "Border"
 msgstr "Bordure"
 
 #: plugins/theme_arc/oomox_plugin.py:174
-#, fuzzy
 msgid "Enable Theme Transparency"
 msgstr "Habilitier la transparence du thème"
 
@@ -658,29 +647,25 @@ msgstr "_Chemin do Spotify :"
 
 #: plugins/oomoxify/oomox_plugin.py:141
 msgid "Apply Spotif_y Theme…"
-msgstr "Appliquer le thème du Spotif_y…"
+msgstr "Appliquer le thème du Spotif_y …"
 
 #: plugins/oomoxify/oomox_plugin.py:147
 msgid "Spotify"
 msgstr "Spotify"
 
 #: plugins/icons_suruplus/oomox_plugin.py:58
-#, fuzzy
 msgid "Export _path: "
 msgstr "EXporter le _chemin :"
 
 #: plugins/icons_suruplus/oomox_plugin.py:116
-#, fuzzy
 msgid "Enable Gradients"
 msgstr "Habilitier dégradés"
 
 #: plugins/icons_suruplus/oomox_plugin.py:122
-#, fuzzy
 msgid "Gradient Start Color"
 msgstr "Couleur du dégradé primaire"
 
 #: plugins/icons_suruplus/oomox_plugin.py:131
-#, fuzzy
 msgid "Gradient End Color"
 msgstr "Couleur du dégradé secondaire"
 
@@ -693,17 +678,14 @@ msgstr ""
 "au lieu de 3.18 et 3,20+"
 
 #: plugins/theme_oomox/oomox_plugin.py:107
-#, fuzzy
 msgid "Textbox Caret"
 msgstr "Curseur de la zone de texte"
 
 #: plugins/theme_oomox/oomox_plugin.py:113
-#, fuzzy
 msgid "BiDi Textbox Caret"
 msgstr "Curseur de la zone de text BiDi"
 
 #: plugins/theme_oomox/oomox_plugin.py:122
-#, fuzzy
 msgid "Textbox Caret Aspect Ratio"
 msgstr "Rapport d'aspect"
 
@@ -744,14 +726,12 @@ msgid "Unity: Use Default Launcher Style"
 msgstr "Unity : Utiliser le style de lanceur par défaut"
 
 #: plugins/import_pil/oomox_plugin.py:56
-#, fuzzy
 msgid "Image colors"
-msgstr "couleurs de l'image"
+msgstr "Couleurs de l'image"
 
 #: plugins/import_pil/oomox_plugin.py:57
-#, fuzzy
 msgid "Colors from Image"
-msgstr "Couleurs de l'image"
+msgstr "Couleurs à partir de l'image"
 
 #: plugins/import_pil/oomox_plugin.py:189
 msgid "Import Colors from Image"
@@ -759,15 +739,15 @@ msgstr "Importer les couleurs de l'image"
 
 #: plugins/import_pil/oomox_plugin.py:200
 msgid "oomox: low quality"
-msgstr "oomox: basse qualité"
+msgstr "oomox : basse qualité"
 
 #: plugins/import_pil/oomox_plugin.py:203
 msgid "oomox: medium quality"
-msgstr "oomox: moyenne qualité"
+msgstr "oomox : moyenne qualité"
 
 #: plugins/import_pil/oomox_plugin.py:206
 msgid "oomox: high quality"
-msgstr "oomox: haute qualité"
+msgstr "oomox : haute qualité"
 
 #: plugins/import_pil/oomox_plugin.py:212
 msgid "Image Analysis"
@@ -783,7 +763,7 @@ msgstr "Continuer à suivre le modèle de la palette"
 
 #: plugins/import_pil/oomox_plugin.py:241
 msgid "Dark/Light Colors"
-msgstr "Couleurs claires/foncéess"
+msgstr "Couleurs claires/foncées"
 
 #: plugins/import_pil/oomox_plugin.py:252
 msgid "GUI Theme Template"
@@ -803,11 +783,11 @@ msgstr "colorz lib: basse qualité"
 
 #: plugins/import_pil/oomox_plugin.py:277
 msgid "colorz lib: medium quality"
-msgstr "colorz lib: moyenne qualité"
+msgstr "colorz lib : moyenne qualité"
 
 #: plugins/import_pil/oomox_plugin.py:280
 msgid "colorz lib: high quality"
-msgstr "colorz lib: haute qualité"
+msgstr "colorz lib : haute qualité"
 
 #: plugins/import_pil/oomox_plugin.py:289
 msgid "colorthief lib"
@@ -815,7 +795,7 @@ msgstr "colorthief lib"
 
 #: plugins/import_pil/oomox_plugin.py:292
 msgid "colorthief lib: doublepass"
-msgstr "colorthief lib: double passe"
+msgstr "colorthief lib : double passe"
 
 #: plugins/import_pil/oomox_plugin.py:302
 msgid "haishoku lib"
@@ -845,11 +825,9 @@ msgstr "Couleurs d'icônes"
 #~ msgid "Secondary Caret Color"
 #~ msgstr "Point d'insertion secondaire"
 
-#, fuzzy
 #~ msgid "_Export Theme…"
 #~ msgstr "_Exporter le thème"
 
-#, fuzzy
 #~ msgid "Selection Highlight"
 #~ msgstr "Surlignage de la sélection"
 
@@ -866,7 +844,7 @@ msgstr "Couleurs d'icônes"
 #~ msgstr "Arrière-plan menu/barre d'outils"
 
 #~ msgid "Menu/toolbar text"
-#~ msgstr "Texte menu/barre d'outils"
+#~ msgstr "Texte du menu/de la barre d'outils"
 
 #~ msgid "Terminal background"
 #~ msgstr "Arrière-plan du terminal"
@@ -880,24 +858,16 @@ msgstr "Couleurs d'icônes"
 #~ msgid "Other options"
 #~ msgstr "Autres options"
 
-#, fuzzy
 #~ msgid "Please choose the font options:"
 #~ msgstr "Veuillez choisir les options de la police :"
 
-#, fuzzy
 #~ msgid "Spotify background"
 #~ msgstr "Arrière-plan du Spotify"
 
-#, fuzzy
 #~ msgid "Spotify foreground"
 #~ msgstr "Avant-plan du Spotify"
 
-#, fuzzy
 #~ msgid "Theme options:"
-#~ msgstr "Options du thème :"
-
-#, fuzzy
-#~ msgid "Theme options: "
 #~ msgstr "Options du thème :"
 
 #~ msgid "Edit:"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: oomox\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-22 07:27+0100\n"
-"PO-Revision-Date: 2019-02-21 20:24-0300\n"
+"PO-Revision-Date: 2019-02-21 11:50-0300\n"
 "Last-Translator: Gustavo Costa <gusbemacbe@gmail.com>\n"
 "Language-Team: Italian <gusbemacbe@gmail.com>\n"
 "Language: it \n"
@@ -72,7 +72,7 @@ msgstr "Opzioni dell'esportazione del tema"
 
 #: oomox_gui/export_common.py:316
 msgid "Generate 2x scaled (_HiDPI) assets for GTK+2"
-msgstr "Generare le immagini (_HiDPI) 2x ridimensionate per GTK+2"
+msgstr "Generare le immagini di (_HiDPI) 2x ridimensionate per GTK+2"
 
 #: oomox_gui/colors_list.py:265
 msgid "Choose a Color…"
@@ -147,7 +147,7 @@ msgid ""
 "There are unsaved changes.\n"
 "Save them?"
 msgstr ""
-"Ci sono odifiche non salvate.\n"
+"Ci sono modifiche non salvate.\n"
 "Vuoi salvarle?"
 
 #: oomox_gui/main.py:76
@@ -319,14 +319,12 @@ msgid "Header Text"
 msgstr "Testo dell'intestazione"
 
 #: oomox_gui/theme_model.py:154
-#, fuzzy
 msgid "Selected Background"
-msgstr "Sfondo da barra di intestazione"
+msgstr "Sfondo selezionato"
 
 #: oomox_gui/theme_model.py:160
-#, fuzzy
 msgid "Selected Text"
-msgstr "Testo di selezione"
+msgstr "Testo selezionato"
 
 #: oomox_gui/theme_model.py:166
 msgid "Accent Color (Checkboxes, Radios)"
@@ -358,11 +356,11 @@ msgstr "Testo do pulsante dell'intestazione"
 
 #: oomox_gui/theme_model.py:208
 msgid "Focused Window Border"
-msgstr "bordo della finestra focalizzata"
+msgstr "Bordo della finestra focalizzata"
 
 #: oomox_gui/theme_model.py:214
 msgid "Unfocused Window Border"
-msgstr "bordo della finestra non focalizzata"
+msgstr "Bordo della finestra non focalizzata"
 
 #: oomox_gui/theme_model.py:235 oomox_gui/theme_model.py:295
 msgid "Theme Options"
@@ -418,7 +416,7 @@ msgstr "Scambio automatico di sfondo e primo piano"
 
 #: oomox_gui/theme_model.py:353
 msgid "Extend Palette with More Lighter/Darker Colors"
-msgstr "Estendere a tavolozza con colori più chiari/scuri"
+msgstr "Estendere la tavolozza con colori più chiari/scuri"
 
 #: oomox_gui/theme_model.py:362
 msgid "Palette Generation Accuracy"
@@ -519,8 +517,7 @@ msgstr "Opzioni dell'esportazione del Base16…"
 
 #: plugins/base16/oomox_plugin.py:258
 msgid "Choose export options below and copy-paste the result."
-msgstr ""
-"Scegli le opzioni dell'esportazione sotto e copia-incolla il risultato."
+msgstr "Scegli le opzioni dell'esportazione sotto e copia-incolla il risultato."
 
 #: plugins/base16/oomox_plugin.py:281
 msgid "_Application:"
@@ -597,9 +594,8 @@ msgid "Border"
 msgstr "Bordo"
 
 #: plugins/theme_arc/oomox_plugin.py:174
-#, fuzzy
 msgid "Enable Theme Transparency"
-msgstr "Abilitare la transparenza del tema del GTK3"
+msgstr "Abilitare la transparenza del tema"
 
 #: plugins/theme_materia/oomox_plugin.py:96
 msgid "View"
@@ -627,7 +623,7 @@ msgstr "Base chiara"
 
 #: plugins/oomoxify/oomox_plugin.py:60
 msgid "Don't change _default font"
-msgstr "Non cambiare il font standard"
+msgstr "Non cambiare il font _standard"
 
 #: plugins/oomoxify/oomox_plugin.py:70
 msgid "_Normalize font weight"
@@ -658,22 +654,18 @@ msgid "Spotify"
 msgstr "Spotify"
 
 #: plugins/icons_suruplus/oomox_plugin.py:58
-#, fuzzy
 msgid "Export _path: "
-msgstr "_Camino del Spotify:"
+msgstr "ESportare il _camino:"
 
 #: plugins/icons_suruplus/oomox_plugin.py:116
-#, fuzzy
 msgid "Enable Gradients"
 msgstr "Abilitare i gradienti"
 
 #: plugins/icons_suruplus/oomox_plugin.py:122
-#, fuzzy
 msgid "Gradient Start Color"
 msgstr "Colore del gradiente primario"
 
 #: plugins/icons_suruplus/oomox_plugin.py:131
-#, fuzzy
 msgid "Gradient End Color"
 msgstr "Colore del gradiente secundario"
 
@@ -686,19 +678,16 @@ msgstr ""
 "invece delle 3.18 e 3.20+"
 
 #: plugins/theme_oomox/oomox_plugin.py:107
-#, fuzzy
 msgid "Textbox Caret"
-msgstr "Testo della casella di testo"
+msgstr "Cursore della casella di testo"
 
 #: plugins/theme_oomox/oomox_plugin.py:113
-#, fuzzy
 msgid "BiDi Textbox Caret"
-msgstr "Testo della casella di testo"
+msgstr "Cursore della casella di testo BiDi"
 
 #: plugins/theme_oomox/oomox_plugin.py:122
-#, fuzzy
 msgid "Textbox Caret Aspect Ratio"
-msgstr "Pulsante de opzioni del cursore"
+msgstr "Pulsante d'opzioni del cursore della casella di testo"
 
 #: plugins/theme_oomox/oomox_plugin.py:126
 msgid "GTK3 Theme Options"
@@ -714,7 +703,7 @@ msgstr "Larghezza del contorno focalizzato"
 
 #: plugins/theme_oomox/oomox_plugin.py:147
 msgid "Focused Button Outline Width"
-msgstr "Larghezza del contorno focalizzato del pulsante"
+msgstr "Larghezza del contorno del pulsante focalizzato"
 
 #: plugins/theme_oomox/oomox_plugin.py:154
 msgid "Focused Button Outline Offset"
@@ -722,7 +711,7 @@ msgstr "Distanza del contorno del pulsante focalizzato"
 
 #: plugins/theme_oomox/oomox_plugin.py:160
 msgid "Add Dark Variant"
-msgstr "Aggiungere variante scura"
+msgstr "Aggiungere una variante scura"
 
 #: plugins/theme_oomox/oomox_plugin.py:165
 msgid "Desktop Environments"
@@ -737,18 +726,16 @@ msgid "Unity: Use Default Launcher Style"
 msgstr "Unity: Utilizzare lo stile del lanciatore standard"
 
 #: plugins/import_pil/oomox_plugin.py:56
-#, fuzzy
 msgid "Image colors"
-msgstr "colori del terminal:"
+msgstr "colori dell'immagine"
 
 #: plugins/import_pil/oomox_plugin.py:57
-#, fuzzy
 msgid "Colors from Image"
-msgstr "Importare i colori dell'immagine"
+msgstr "Colori dall'immagine"
 
 #: plugins/import_pil/oomox_plugin.py:189
 msgid "Import Colors from Image"
-msgstr "Importare i colori dell'immagine"
+msgstr "Importare i colori dall'immagine"
 
 #: plugins/import_pil/oomox_plugin.py:200
 msgid "oomox: low quality"
@@ -784,7 +771,7 @@ msgstr "Template del tema del GUI"
 
 #: plugins/import_pil/oomox_plugin.py:259
 msgid "Image Thumbnail"
-msgstr "Miniatura dell'immagine"
+msgstr "Miniatura d'immagine"
 
 #: plugins/import_pil/oomox_plugin.py:262
 msgid "Edit Generated Theme"
@@ -833,16 +820,14 @@ msgstr "Colore di icone"
 #~ msgstr "Colore del borde dei widget del GTK3"
 
 #~ msgid "Text Input Caret"
-#~ msgstr "Cursore"
+#~ msgstr "Cursore dell'immissione di testo"
 
 #~ msgid "Secondary Caret Color"
 #~ msgstr "Colore del cursore secondario"
 
-#, fuzzy
 #~ msgid "_Export Theme…"
 #~ msgstr "_Esportare il tema..."
 
-#, fuzzy
 #~ msgid "Selection Highlight"
 #~ msgstr "Evidenziatore di selezione"
 
@@ -873,25 +858,17 @@ msgstr "Colore di icone"
 #~ msgid "Other options"
 #~ msgstr "Altre opzioni"
 
-#, fuzzy
 #~ msgid "Please choose the font options:"
 #~ msgstr "Per favore scegli le opzioni del font:"
 
-#, fuzzy
 #~ msgid "Spotify background"
 #~ msgstr "Sfondo del Spotify"
 
-#, fuzzy
 #~ msgid "Spotify foreground"
 #~ msgstr "Primo piano del Spotify"
 
-#, fuzzy
 #~ msgid "Theme options:"
-#~ msgstr "Opzioni del tena:"
-
-#, fuzzy
-#~ msgid "Theme options: "
-#~ msgstr "Opzioni del tena:"
+#~ msgstr "Opzioni del tema:"
 
 #~ msgid "Edit:"
 #~ msgstr "Modificare:"

--- a/po/nl_NL.po
+++ b/po/nl_NL.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: oomox\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-22 07:27+0100\n"
-"PO-Revision-Date: 2019-02-22 14:00+0100\n"
-"Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
+"PO-Revision-Date: 2019-02-21 11:50-0300\n"
+"Last-Translator: Gustavo Costa <gusbemacbe@gmail.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
@@ -825,11 +825,9 @@ msgstr "Pictogramkleur"
 #~ msgid "Secondary Caret Color"
 #~ msgstr "Secundaire cursorkleur"
 
-#, fuzzy
 #~ msgid "_Export Theme…"
 #~ msgstr "Thema _exporteren"
 
-#, fuzzy
 #~ msgid "Selection Highlight"
 #~ msgstr "Selectiemarkering"
 
@@ -860,25 +858,17 @@ msgstr "Pictogramkleur"
 #~ msgid "Other options"
 #~ msgstr "Overige opties"
 
-#, fuzzy
 #~ msgid "Please choose the font options:"
 #~ msgstr "Kies thema-exporteringsopties:"
 
-#, fuzzy
 #~ msgid "Spotify background"
 #~ msgstr "Knopachtergrond"
 
-#, fuzzy
 #~ msgid "Spotify foreground"
 #~ msgstr "Spotify-opties"
 
-#, fuzzy
 #~ msgid "Theme options:"
-#~ msgstr "Thema-opties"
-
-#, fuzzy
-#~ msgid "Theme options: "
-#~ msgstr "Thema-opties"
+#~ msgstr "Thema-opties:"
 
 #~ msgid "Edit:"
 #~ msgstr "Bewerken:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: oomox\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-22 07:27+0100\n"
-"PO-Revision-Date: 2019-02-22 03:56-0300\n"
+"PO-Revision-Date: 2019-02-21 11:50-0300\n"
 "Last-Translator: Gustavo Costa <gusbemacbe@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <gusbemacbe@gmail.com>\n"
 "Language: pt_BR \n"
@@ -48,7 +48,7 @@ msgstr "_Aplicar e exportar opções"
 
 #: oomox_gui/export_common.py:146
 msgid "Exporting…"
-msgstr "Exportando..."
+msgstr "Exportando…"
 
 #: oomox_gui/export_common.py:158
 msgid ""
@@ -64,7 +64,7 @@ msgstr "Esquema de cores do terminal"
 
 #: oomox_gui/export_common.py:207
 msgid "Paste this colorscheme to your ~/.Xresources:"
-msgstr "Copie esse equema de cores para seu ~/.Xresources:"
+msgstr "Cole esse esquema de cores para seu ~/.Xresources:"
 
 #: oomox_gui/export_common.py:244
 msgid "Theme Export Options"
@@ -257,7 +257,7 @@ msgstr "_Sim"
 #: oomox_gui/plugin_loader.py:54
 #, python-brace-format
 msgid "Error loading plugin \"{plugin_name}\""
-msgstr "Erro carregando \"{plugin_name}\""
+msgstr "Erro de carregar o plugin \"{plugin_name}\""
 
 #: oomox_gui/preview.py:62
 msgid "Headerbar"
@@ -281,7 +281,7 @@ msgstr "Isso é uma etiqueta"
 
 #: oomox_gui/preview.py:103
 msgid "Selected item"
-msgstr "Itens selecionados"
+msgstr "Item selecionado"
 
 #: oomox_gui/preview.py:104
 msgid "Text entry"
@@ -319,18 +319,16 @@ msgid "Header Text"
 msgstr "Texto do cabeçalho"
 
 #: oomox_gui/theme_model.py:154
-#, fuzzy
 msgid "Selected Background"
-msgstr "Fundo da barra de cabeçalho"
+msgstr "Fundo selecionado"
 
 #: oomox_gui/theme_model.py:160
-#, fuzzy
 msgid "Selected Text"
-msgstr "Texto da seleção"
+msgstr "Texto selecionado"
 
 #: oomox_gui/theme_model.py:166
 msgid "Accent Color (Checkboxes, Radios)"
-msgstr "Cor de destaque (caixas de seleção, botões de rádio)"
+msgstr "Cor de destaque (caixas de seleção, botões de opções)"
 
 #: oomox_gui/theme_model.py:172
 msgid "Textbox Background"
@@ -572,12 +570,12 @@ msgstr "Modificar o tema importado"
 #: plugins/icons_papirus/oomox_plugin.py:62
 #: plugins/icons_suruplus/oomox_plugin.py:103
 msgid "Actions Icons"
-msgstr "_Ícones de actions"
+msgstr "Ícones de actions"
 
 #: plugins/icons_papirus/oomox_plugin.py:68
 #: plugins/icons_suruplus/oomox_plugin.py:109
 msgid "Panel Icons"
-msgstr "_Ícones de panel"
+msgstr "Ícones de panel"
 
 #: plugins/theme_arc/oomox_plugin.py:55 plugins/theme_oomox/oomox_plugin.py:59
 msgid "Generate theme for _Cinnamon"
@@ -596,9 +594,8 @@ msgid "Border"
 msgstr "Borda"
 
 #: plugins/theme_arc/oomox_plugin.py:174
-#, fuzzy
 msgid "Enable Theme Transparency"
-msgstr "Ativar a transparência do tema do GTK3"
+msgstr "Ativar a transparência do tema"
 
 #: plugins/theme_materia/oomox_plugin.py:96
 msgid "View"
@@ -626,7 +623,7 @@ msgstr "Base clara"
 
 #: plugins/oomoxify/oomox_plugin.py:60
 msgid "Don't change _default font"
-msgstr "Não mude a fonte padrão"
+msgstr "Não mude a fonte _padrão"
 
 #: plugins/oomoxify/oomox_plugin.py:70
 msgid "_Normalize font weight"
@@ -657,22 +654,18 @@ msgid "Spotify"
 msgstr "Spotify"
 
 #: plugins/icons_suruplus/oomox_plugin.py:58
-#, fuzzy
 msgid "Export _path: "
-msgstr "_Caminho do Spotify:"
+msgstr "Exportar o _caminho:"
 
 #: plugins/icons_suruplus/oomox_plugin.py:116
-#, fuzzy
 msgid "Enable Gradients"
 msgstr "Habilitar os gradientes"
 
 #: plugins/icons_suruplus/oomox_plugin.py:122
-#, fuzzy
 msgid "Gradient Start Color"
 msgstr "Cor do gradiente primário"
 
 #: plugins/icons_suruplus/oomox_plugin.py:131
-#, fuzzy
 msgid "Gradient End Color"
 msgstr "Cor do gradiente secundário"
 
@@ -685,19 +678,16 @@ msgstr ""
 "ao invés de ambas as 3.18 e 3.20+"
 
 #: plugins/theme_oomox/oomox_plugin.py:107
-#, fuzzy
 msgid "Textbox Caret"
-msgstr "Texto da caixa do texto"
+msgstr "Indicador da caixa do texto"
 
 #: plugins/theme_oomox/oomox_plugin.py:113
-#, fuzzy
 msgid "BiDi Textbox Caret"
-msgstr "Texto da caixa do texto"
+msgstr "Indicador da caixa do texto BiDi"
 
 #: plugins/theme_oomox/oomox_plugin.py:122
-#, fuzzy
 msgid "Textbox Caret Aspect Ratio"
-msgstr "Botão de rádio do aspecto do indicador"
+msgstr "Botão de opções do indicador"
 
 #: plugins/theme_oomox/oomox_plugin.py:126
 msgid "GTK3 Theme Options"
@@ -736,14 +726,12 @@ msgid "Unity: Use Default Launcher Style"
 msgstr "Unity: Usar o estilo do lançador padrão"
 
 #: plugins/import_pil/oomox_plugin.py:56
-#, fuzzy
 msgid "Image colors"
-msgstr "cores do terminal:"
+msgstr "Cores do terminal"
 
 #: plugins/import_pil/oomox_plugin.py:57
-#, fuzzy
 msgid "Colors from Image"
-msgstr "Importar as cores da imagem"
+msgstr "Cores a partir da imagem"
 
 #: plugins/import_pil/oomox_plugin.py:189
 msgid "Import Colors from Image"
@@ -832,16 +820,14 @@ msgstr "Cor de ícones"
 #~ msgstr "Cor da borda dos widgets do GTK3"
 
 #~ msgid "Text Input Caret"
-#~ msgstr "Indicador"
+#~ msgstr "Indicador da entrada de texto"
 
 #~ msgid "Secondary Caret Color"
 #~ msgstr "Cor do indicador secundário"
 
-#, fuzzy
 #~ msgid "_Export Theme…"
 #~ msgstr "_Exportar o tema"
 
-#, fuzzy
 #~ msgid "Selection Highlight"
 #~ msgstr "Marcador de seleção"
 
@@ -872,24 +858,16 @@ msgstr "Cor de ícones"
 #~ msgid "Other options"
 #~ msgstr "Outras opções"
 
-#, fuzzy
 #~ msgid "Please choose the font options:"
 #~ msgstr "Por favor escolha as opções da fonte:"
 
-#, fuzzy
 #~ msgid "Spotify background"
 #~ msgstr "Fundo do Spotify"
 
-#, fuzzy
 #~ msgid "Spotify foreground"
 #~ msgstr "Primeiro plano do Spotify"
 
-#, fuzzy
 #~ msgid "Theme options:"
-#~ msgstr "Opções do tena:"
-
-#, fuzzy
-#~ msgid "Theme options: "
 #~ msgstr "Opções do tena:"
 
 #~ msgid "Edit:"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: oomox\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-02-22 07:27+0100\n"
-"PO-Revision-Date: 2019-02-22 04:05-0300\n"
+"PO-Revision-Date: 2019-02-21 11:50-0300\n"
 "Last-Translator: Gustavo Costa <gusbemacbe@gmail.com>\n"
 "Language-Team: European Portuguese <gusbemacbe@gmail.com>\n"
 "Language: pt_PT \n"
@@ -64,7 +64,7 @@ msgstr "Esquema de cores do terminal"
 
 #: oomox_gui/export_common.py:207
 msgid "Paste this colorscheme to your ~/.Xresources:"
-msgstr "Copia este equema de cores para teu ~/.Xresources:"
+msgstr "Cola este equema de cores para teu ~/.Xresources:"
 
 #: oomox_gui/export_common.py:244
 msgid "Theme Export Options"
@@ -132,7 +132,7 @@ msgstr "Novo tema"
 
 #: oomox_gui/main.py:40
 msgid "Please input new theme name:"
-msgstr "Por favor, insere o nome do tema:"
+msgstr "Por favor, introduz o nome do tema:"
 
 #: oomox_gui/main.py:56
 msgid "Rename Theme"
@@ -176,7 +176,7 @@ msgstr "Esquema de cores com este nome já existe"
 
 #: oomox_gui/main.py:498 oomox_gui/main.py:652
 msgid "Oo-mox GUI"
-msgstr "UI do Oo-mox"
+msgstr "Interface gráfica do Oo-mox"
 
 #: oomox_gui/main.py:506
 msgid "Oomox Colors File"
@@ -319,18 +319,16 @@ msgid "Header Text"
 msgstr "Texto do cabeçalho"
 
 #: oomox_gui/theme_model.py:154
-#, fuzzy
 msgid "Selected Background"
-msgstr "Fundo da barra de cabeçalho"
+msgstr "Fundo seleccionado"
 
 #: oomox_gui/theme_model.py:160
-#, fuzzy
 msgid "Selected Text"
-msgstr "Texto da selecção"
+msgstr "Texto seleccionado"
 
 #: oomox_gui/theme_model.py:166
 msgid "Accent Color (Checkboxes, Radios)"
-msgstr "Cor de destaque (caixas de selecção, botões de rádio)"
+msgstr "Cor de destaque (caixas de selecção, botões de opções)"
 
 #: oomox_gui/theme_model.py:172
 msgid "Textbox Background"
@@ -596,9 +594,8 @@ msgid "Border"
 msgstr "Borda"
 
 #: plugins/theme_arc/oomox_plugin.py:174
-#, fuzzy
 msgid "Enable Theme Transparency"
-msgstr "Habilitar a transparência do tema do GTK3"
+msgstr "Habilitar a transparência do tema"
 
 #: plugins/theme_materia/oomox_plugin.py:96
 msgid "View"
@@ -626,7 +623,7 @@ msgstr "Base clara"
 
 #: plugins/oomoxify/oomox_plugin.py:60
 msgid "Don't change _default font"
-msgstr "Não modifiques o tipo de caractere padrão"
+msgstr "Não modifiques o tipo de caractere _padrão"
 
 #: plugins/oomoxify/oomox_plugin.py:70
 msgid "_Normalize font weight"
@@ -657,24 +654,20 @@ msgid "Spotify"
 msgstr "Spotify"
 
 #: plugins/icons_suruplus/oomox_plugin.py:58
-#, fuzzy
 msgid "Export _path: "
-msgstr "_Caminho do Spotify:"
+msgstr "Exportar o _caminho:"
 
 #: plugins/icons_suruplus/oomox_plugin.py:116
-#, fuzzy
 msgid "Enable Gradients"
-msgstr "Gradiente"
+msgstr "Habilitar os gradientes"
 
 #: plugins/icons_suruplus/oomox_plugin.py:122
-#, fuzzy
 msgid "Gradient Start Color"
-msgstr "Cor do indicador primário"
+msgstr "Cor do gradiente primário"
 
 #: plugins/icons_suruplus/oomox_plugin.py:131
-#, fuzzy
 msgid "Gradient End Color"
-msgstr "Gradiente"
+msgstr "Cor do gradiente secundário"
 
 #: plugins/theme_oomox/oomox_plugin.py:54
 msgid ""
@@ -685,19 +678,16 @@ msgstr ""
 "ao invés de ambas as 3.18 e 3.20+"
 
 #: plugins/theme_oomox/oomox_plugin.py:107
-#, fuzzy
 msgid "Textbox Caret"
-msgstr "Texto da caixa do texto"
+msgstr "Indicador da caixa do texto"
 
 #: plugins/theme_oomox/oomox_plugin.py:113
-#, fuzzy
 msgid "BiDi Textbox Caret"
-msgstr "Texto da caixa do texto"
+msgstr "Indicador da caixa do texto BiDi"
 
 #: plugins/theme_oomox/oomox_plugin.py:122
-#, fuzzy
 msgid "Textbox Caret Aspect Ratio"
-msgstr "Botão de rádio do aspecto do indicador"
+msgstr "Botão de opções do indicador"
 
 #: plugins/theme_oomox/oomox_plugin.py:126
 msgid "GTK3 Theme Options"
@@ -717,7 +707,7 @@ msgstr "Largura de contorno focalizado do botão"
 
 #: plugins/theme_oomox/oomox_plugin.py:154
 msgid "Focused Button Outline Offset"
-msgstr "Distância do contorno do botão focalizado"
+msgstr "Distância do contorno focalizado do botão"
 
 #: plugins/theme_oomox/oomox_plugin.py:160
 msgid "Add Dark Variant"
@@ -725,7 +715,7 @@ msgstr "Aderir variante escura"
 
 #: plugins/theme_oomox/oomox_plugin.py:165
 msgid "Desktop Environments"
-msgstr "Ambientes da áre do trabalho"
+msgstr "Ambientes da área do trabalho"
 
 #: plugins/theme_oomox/oomox_plugin.py:175
 msgid "Cinnamon: Opacity"
@@ -736,14 +726,12 @@ msgid "Unity: Use Default Launcher Style"
 msgstr "Unity: Utilizar o estilo do lançador padrão"
 
 #: plugins/import_pil/oomox_plugin.py:56
-#, fuzzy
 msgid "Image colors"
-msgstr "cores do terminal:"
+msgstr "Cores da imagem"
 
 #: plugins/import_pil/oomox_plugin.py:57
-#, fuzzy
 msgid "Colors from Image"
-msgstr "Importar as cores da imagem"
+msgstr "Cores a partir da imagem"
 
 #: plugins/import_pil/oomox_plugin.py:189
 msgid "Import Colors from Image"
@@ -832,16 +820,14 @@ msgstr "Cor de ícones"
 #~ msgstr "Cor da borda dos widgets do GTK3"
 
 #~ msgid "Text Input Caret"
-#~ msgstr "Indicador"
+#~ msgstr "Indicador da entrada de texto"
 
 #~ msgid "Secondary Caret Color"
 #~ msgstr "Cor do indicador secundário"
 
-#, fuzzy
 #~ msgid "_Export Theme…"
 #~ msgstr "_Exportar o tema"
 
-#, fuzzy
 #~ msgid "Selection Highlight"
 #~ msgstr "Marcador de selecção"
 
@@ -872,24 +858,16 @@ msgstr "Cor de ícones"
 #~ msgid "Other options"
 #~ msgstr "Outras opções"
 
-#, fuzzy
 #~ msgid "Please choose the font options:"
 #~ msgstr "Por favor escolhe as opções do tipo de caractere:"
 
-#, fuzzy
 #~ msgid "Spotify background"
 #~ msgstr "Fundo do Spotify"
 
-#, fuzzy
 #~ msgid "Spotify foreground"
 #~ msgstr "Primeiro plano do Spotify"
 
-#, fuzzy
 #~ msgid "Theme options:"
-#~ msgstr "Opções do tena:"
-
-#, fuzzy
-#~ msgid "Theme options: "
 #~ msgstr "Opções do tena:"
 
 #~ msgid "Edit:"


### PR DESCRIPTION
Hello @actionless !

* I have fixed the misspeling "Backround" to "Background" in all Dutch, French, Italian, Portuguese and Spanish;
* I have removed the duplicated strings `#~ msgid "Theme options:"` in all Dutch, French, Italian, Portuguese and Spanish;
* I have removed "fuzzy" and fixed missed symbols in the Dutch translation;
* I have corrected the misspellings, fuzzy translations and improved the other translations in the French, Italian, Portuguese and Spanish.

## Observation:

BiDi is the same in all languages. But I do not know if it is bad to insert the whole name of that abbreviation like: "testo bidirezionale", "texto bidireccional", "texte bidirectionnel", "bidirectionele tekst", etc.