### PR TITLE
fixed highlighted text color

### DIFF
--- a/colors/Xresources/xresources-reverse
+++ b/colors/Xresources/xresources-reverse
@@ -5,7 +5,7 @@
              TXT_BG=xrdb.background
              TXT_FG=xrdb.color7
              SEL_BG=xrdb.color3
-             SEL_FG=xrdb.color0
+             SEL_FG=xrdb.background
             MENU_BG=xrdb.color0
             MENU_FG=xrdb.color7
              BTN_BG=xrdb.color12

--- a/scripted_colors/xresources/xresources-reverse
+++ b/scripted_colors/xresources/xresources-reverse
@@ -18,7 +18,7 @@ color_fg () {
  TXT_BG=$(color_bg)
  TXT_FG=$(color 7)
  SEL_BG=$(color 6)
- SEL_FG=$TXT_FG
+ SEL_FG=$TXT_BG
 HDR_BG=$(color_bg)
 HDR_FG=$FG
  BTN_BG=$(color 12)


### PR DESCRIPTION
A few months ago I whipped up the `xresources-reverse` theme to create a pywal themed "dark mode" theme. However the when a menu item is selected, the text is extremely hard to read against the bright selection highlight.

Now text shown for a selected item is black, or the color of the background so the contrast is better!