### PR TITLE
Enhance ubuntu packaging with fakeroot usage and __pycache__ cleanup

### DIFF
--- a/packaging/ubuntu/Dockerfile_cosmic
+++ b/packaging/ubuntu/Dockerfile_cosmic
@@ -1,5 +1,5 @@
 FROM ubuntu:cosmic
 WORKDIR /opt/oomox
 CMD ["/bin/bash", "./packaging/ubuntu/create_ubuntu_package.sh", "control_1810", "--install"]
-RUN apt update --allow-unauthenticated && apt install -y make gettext
+RUN apt update --allow-unauthenticated && apt install -y make gettext fakeroot
 COPY . /opt/oomox/

--- a/packaging/ubuntu/Dockerfile_zesty
+++ b/packaging/ubuntu/Dockerfile_zesty
@@ -3,5 +3,5 @@ WORKDIR /opt/oomox
 CMD ["/bin/bash", "./packaging/ubuntu/create_ubuntu_package.sh", "control", "--install"]
 RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y make gettext
+    apt-get install -y make gettext fakeroot
 COPY . /opt/oomox/

--- a/packaging/ubuntu/create_ubuntu_package.sh
+++ b/packaging/ubuntu/create_ubuntu_package.sh
@@ -14,13 +14,14 @@ pkgdir=$(readlink -e ./${_pkgdirname})
 
 mkdir "${pkgdir}"/DEBIAN
 cp "${srcdir}"/packaging/ubuntu/postinst "${pkgdir}"/DEBIAN
+cp "${srcdir}"/packaging/ubuntu/prerm    "${pkgdir}"/DEBIAN
 cp "${srcdir}"/packaging/ubuntu/"${control_file}" "${pkgdir}"/DEBIAN/control
 
 cd "${srcdir}"
 make DESTDIR="${pkgdir}" install
 
 cd "${pkgdir}"
-dpkg-deb --build . oomox.deb
+fakeroot dpkg-deb --build . oomox.deb
 if [[ "${2:-}" = "--install" ]] ; then
 	apt install -y --no-install-recommends ./oomox.deb
 fi

--- a/packaging/ubuntu/prerm
+++ b/packaging/ubuntu/prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Shamelessly modified from dh_python3:
+if which py3clean >/dev/null 2>&1; then
+	py3clean /opt/oomox/oomox_gui
+else
+	rm -rf /opt/oomox/oomox_gui/__pycache__
+fi
+
+


### PR DESCRIPTION
Using fakeroot creates a package with the right ownership.
Cleaning precompiled .pyc files generated from postinst avoids leaving files behind us when uninstalling and prevents the corresponding dpkg warning to show up.