### PR TITLE
Added hacky drop-down with "replace all instances" on color rows

### DIFF
--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -333,7 +333,7 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
         return self.drop_down
 
     def replace_all_instances(self, menu_item):  # pylint:disable=unused-argument
-        menu_item = menu_item
+        menu_item = self.menu_item
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.get_fuzzy_sibling(OomoxColorButton).gtk_color
         )

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -323,7 +323,7 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
     def build_dropdown_menu(self):
         self.drop_down = Gtk.Menu()
         menu_items = []
-        menu_items.append([Gtk.MenuItem(label="Replace all instances"), self.replace_all_instances])
+        menu_items.append([Gtk.MenuItem(label=_("Replace all instances")), self.replace_all_instances])
 
         for item in menu_items:
             self.drop_down.append(item[0])

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -318,7 +318,6 @@ class OomoxColorButton(Gtk.Button):
         while not isinstance(pot_parent, Gtk.ListBox):
             pot_parent = pot_parent.get_parent()
             if isinstance(pot_parent, Gtk.Application):
-                print("Looked for ListBox parent of {}, and ended up running into the Application parent (i.e., didn't find a ListBox parent).".format(str(self)))
                 break
         else:
             return pot_parent

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -357,7 +357,7 @@ class ColorListBoxRow(OomoxListBoxRow):
         self.value = convert_gdk_to_theme_color(gtk_value)
         self.color_entry.set_text(self.value)
 
-    def set_value(self, value, connected=False): # pylint: disable=arguments-differ
+    def set_value(self, value, connected=False):  # pylint: disable=arguments-differ
         if connected is False:
             self.disconnect_changed_signal()
         self.value = value

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -333,7 +333,9 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
         return self.drop_down
 
     def replace_all_instances(self, _menu_item):  # pylint:disable=unused-argument
-        menu_item = self.menu_item
+
+        _menu_item = self.menu_item
+
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.get_fuzzy_sibling(OomoxColorButton).gtk_color
         )

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -334,7 +334,7 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
 
     def replace_all_instances(self, _menu_item):  # pylint:disable=unused-argument
 
-        _menu_item = self.menu_item
+        _menu_item = self._menu_item  # noqa: F841
 
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.get_fuzzy_sibling(OomoxColorButton).gtk_color

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -326,12 +326,13 @@ class OomoxColorButton(Gtk.Button):
         )
         color_selection_dialog.run()
         new_color = color_selection_dialog.gtk_color
-        new_color.string = convert_gdk_to_theme_color(new_color)
-        old_color = convert_gdk_to_theme_color(self.gtk_color)
-        for lbr in self.get_listbox_parent().get_children():
-            if isinstance(lbr, ColorListBoxRow) and lbr.color_button.gtk_color is not None:
-                if convert_gdk_to_theme_color(lbr.color_button.gtk_color) == old_color:
-                    lbr.set_value(new_color.string, connected=True)
+        if new_color:
+            new_color.string = convert_gdk_to_theme_color(new_color)
+            old_color = convert_gdk_to_theme_color(self.gtk_color)
+            for lbr in self.get_listbox_parent().get_children():
+                if isinstance(lbr, ColorListBoxRow) and lbr.color_button.gtk_color is not None:
+                    if convert_gdk_to_theme_color(lbr.color_button.gtk_color) == old_color:
+                        lbr.set_value(new_color.string, connected=True)
 
     def get_listbox_parent(self):
         pot_parent = self.get_parent()

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -333,6 +333,7 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
         return self.drop_down
 
     def replace_all_instances(self, menu_item):  # pylint:disable=unused-argument
+        menu_item = menu_item
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.get_fuzzy_sibling(OomoxColorButton).gtk_color
         )

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -320,7 +320,7 @@ class OomoxColorButton(Gtk.Button):
     def set_value(self, value):
         self.set_rgba(convert_theme_color_to_gdk(value or FALLBACK_COLOR))
 
-    def replace_all_instances(self, menu_item):
+    def replace_all_instances(self, menu_item):  # pylint:disable=unused-argument
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.gtk_color
         )

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -357,7 +357,7 @@ class ColorListBoxRow(OomoxListBoxRow):
         self.value = convert_gdk_to_theme_color(gtk_value)
         self.color_entry.set_text(self.value)
 
-    def set_value(self, value, connected=False):
+    def set_value(self, value, connected=False): # pylint: disable=arguments-differ
         if connected is False:
             self.disconnect_changed_signal()
         self.value = value

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -307,7 +307,7 @@ class OomoxColorButton(Gtk.Button):
             elif _event.button == 3:
                 for lbr in self.get_listbox_parent().get_children():
                     if isinstance(lbr, ColorListBoxRow) and lbr.color_button.gtk_color is not None:
-                        if convert_gdk_to_theme_color(lbr.color_button.gtk_color)==old_color:
+                        if convert_gdk_to_theme_color(lbr.color_button.gtk_color) == old_color:
                             lbr.set_value(new_color.string, connected=True)
 
     def set_value(self, value):

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -340,17 +340,20 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
         new_color = color_selection_dialog.gtk_color
         if new_color:
             new_color.string = convert_gdk_to_theme_color(new_color)
-            old_color = convert_gdk_to_theme_color(self.get_fuzzy_sibling(OomoxColorButton).gtk_color)
-            for listboxrow in self.get_fuzzy_ancestor(Gtk.ListBox).get_children():
-                if isinstance(listboxrow, ColorListBoxRow) and listboxrow.color_button.gtk_color is not None:
-                    if convert_gdk_to_theme_color(listboxrow.color_button.gtk_color) == old_color:
-                        listboxrow.set_value(new_color.string, connected=True)
+            old_color = self.get_fuzzy_sibling(OomoxColorButton).gtk_color
+            old_color.string = convert_gdk_to_theme_color(old_color)
+
+            cousins = self.get_fuzzy_ancestor(Gtk.ListBox).get_children()
+            for lbr in cousins:
+                if isinstance(lbr, ColorListBoxRow) and lbr.color_button.gtk_color is not None:
+                    if convert_gdk_to_theme_color(lbr.color_button.gtk_color) == old_color.string:
+                        lbr.set_value(new_color.string, connected=True)
 
     def get_fuzzy_ancestor(self, desired_class):
         potential_ancestor = self.get_parent()
         while not isinstance(potential_ancestor, desired_class):
             potential_ancestor = potential_ancestor.get_parent()
-            if isinstance(potential_ancestor, Gtk.Window):
+            if isinstance(potential_ancestor, Gtk.Application):
                 break
         else:
             return potential_ancestor

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -334,8 +334,6 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
 
     def replace_all_instances(self, _menu_item):  # pylint:disable=unused-argument
 
-        _menu_item = self._menu_item  # noqa: F841
-
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.get_fuzzy_sibling(OomoxColorButton).gtk_color
         )
@@ -427,8 +425,8 @@ class ColorListBoxRow(OomoxListBoxRow):
             linked_box.get_style_context(), "linked"
         )
         linked_box.add(self.color_entry)
-        linked_box.add(self.menu_button)
         linked_box.add(self.color_button)
+        linked_box.add(self.menu_button)
         super().__init__(
             display_name=display_name,
             key=key,

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -363,6 +363,7 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
         for potential_sibling in potential_siblings:
             if isinstance(potential_sibling, desired_class):
                 return potential_sibling
+        return None
 
     def __init__(self, transient_for):
         super().__init__()

--- a/oomox_gui/colors_list.py
+++ b/oomox_gui/colors_list.py
@@ -332,7 +332,7 @@ class OomoxLinkedDropdown(Gtk.MenuButton):
         self.drop_down.show_all()
         return self.drop_down
 
-    def replace_all_instances(self, menu_item):  # pylint:disable=unused-argument
+    def replace_all_instances(self, _menu_item):  # pylint:disable=unused-argument
         menu_item = self.menu_item
         color_selection_dialog = OomoxColorSelectionDialog(
             self.transient_for, self.get_fuzzy_sibling(OomoxColorButton).gtk_color


### PR DESCRIPTION
I probably need help on this; but I _really_ want to be able to change all matching colors in the ColorsList globally somehow. With this pull, you can functionally right click on a colorbutton and all rows with matching colors will also be changed to the selected color.

It's a small modification, but it's definitely not done the correct way. Please point me in the correct direction.

Modified colors_list.OomoxColorButton:
  * changed __init__ so that on_click is linked to "button_pressed_event" event vs. "clicked" signal to allow to detect left(1) vs right(3) click
  * implemented get_listbox_parent to reference button's parent ListBox object
  * changed colors_list.OomoxColorButton.on_click to use the above to iterate through sibling listboxrows and modify those that match the original value
  * had to modify colors_list.ColorListBoxRow.set_value func, adding a kword arg so that it would stay connected to update the preview the way I wanted