### PR TITLE
Add missing python-cairo dependency on Arch

### DIFF
--- a/packaging/arch/PKGBUILD_gui
+++ b/packaging/arch/PKGBUILD_gui
@@ -17,6 +17,7 @@ md5sums=('SKIP')
 depends=(
 	'gtk3'
 	'python-gobject'
+	'python-cairo'
 )
 makedepends=(
 	'git'


### PR DESCRIPTION
Fixes #349