### PR TITLE
Add utf-8 hint to to oomox_gui/terminal.py

### DIFF
--- a/oomox_gui/terminal.py
+++ b/oomox_gui/terminal.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import sys
 import re


### PR DESCRIPTION
This resolves an xgettext error when building.