### PR TITLE
PKGBUILD quick fix for certain environments

### DIFF
--- a/packaging/arch/PKGBUILD_icons_archdroid
+++ b/packaging/arch/PKGBUILD_icons_archdroid
@@ -59,6 +59,7 @@ package() {
 
 	cd "$pkg_tmp_dir"
 	make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+  cd "$pkgdir"
 	rm -fr "$pkg_tmp_dir"
 
 	python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_icons_gnome_colors
+++ b/packaging/arch/PKGBUILD_icons_gnome_colors
@@ -64,6 +64,7 @@ package() {
 
 	cd "$pkg_tmp_dir"
 	make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+  cd "$pkgdir"
 	rm -fr "$pkg_tmp_dir"
 
 	python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_icons_numix
+++ b/packaging/arch/PKGBUILD_icons_numix
@@ -64,6 +64,7 @@ package() {
 
 	cd "$pkg_tmp_dir"
 	make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+  cd "$pkgdir"
 	rm -fr "$pkg_tmp_dir"
 
 	python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_icons_papirus
+++ b/packaging/arch/PKGBUILD_icons_papirus
@@ -58,6 +58,7 @@ package() {
 
 	cd "$pkg_tmp_dir"
 	make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+  cd "$pkgdir"
 	rm -fr "$pkg_tmp_dir"
 
 	python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_icons_suruplus
+++ b/packaging/arch/PKGBUILD_icons_suruplus
@@ -58,6 +58,7 @@ package() {
 
 	cd "$pkg_tmp_dir"
 	make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+  cd "$pkgdir"
 	rm -fr "$pkg_tmp_dir"
 
 	python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_icons_suruplus_aspromauros
+++ b/packaging/arch/PKGBUILD_icons_suruplus_aspromauros
@@ -56,6 +56,7 @@ package() {
 
 	cd "$pkg_tmp_dir"
 	make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+  cd "$pkgdir"
 	rm -fr "$pkg_tmp_dir"
 
 	python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_theme_arc
+++ b/packaging/arch/PKGBUILD_theme_arc
@@ -69,6 +69,7 @@ package() {
 
        cd "$pkg_tmp_dir"
        make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+       cd "$pkgdir"
        rm -fr "$pkg_tmp_dir"
 
        python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"

--- a/packaging/arch/PKGBUILD_theme_materia
+++ b/packaging/arch/PKGBUILD_theme_materia
@@ -72,6 +72,7 @@ package() {
 
        cd "$pkg_tmp_dir"
        make DESTDIR="${pkgdir}" APPDIR="${_oomox_dir}" PREFIX="/usr" "install_${_plugin_name}"
+       cd "$pkgdir"
        rm -fr "$pkg_tmp_dir"
 
        python -O -m compileall "${pkgdir}${_oomox_dir}/plugins/${_plugin_name}" -d "${_oomox_dir}/plugins/${_plugin_name}"


### PR DESCRIPTION
On my machine, the build fails with `shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory` at the `python -O -m compileall [...]` line. The line immediately before the issue manifests deletes the cwd (`rm -fr "$pkg_tmp_dir"`). makepkg succeeds when either `rm -fr "$pkg_tmp_dir"` is removed or `cd -` is added right before it.

I'm having difficulty determining why this happens in my environment. It happens for me in both bash and zsh (and `bash --norc --noprofile`). The issue has existed for months, so it's likely not some other package being broken. Probably some configuration values for python or the shells are causing it.

This is the only PKGBUILD I've had this issue with, and deleting the cwd seems iffy enough to be worth changing the PKGBUILD to resolve this imo.

I'd recommend adding `cd "$pkgdir"` right before `rm -fr "$pkg_tmp_dir"`, as I've done in this PR.

Thank you for your time!